### PR TITLE
Error when calling enableAdvertisingIdCollection on Android

### DIFF
--- a/www/analytics.js
+++ b/www/analytics.js
@@ -138,7 +138,7 @@ Analytics.prototype = {
 
   enableAdvertisingIdCollection: function (success, error) {
        argscheck.checkArgs('FF', 'analytics.enableAdvertisingIdCollection', arguments);
-       exec(success, error, 'GoogleAnalytics', 'setIDFAEnabled');
+       exec(success, error, 'GoogleAnalytics', 'setIDFAEnabled', []);
   },
 
   get: function (key, success, error) {


### PR DESCRIPTION
Receiving "cannot read property length of undefined" on Android when calling enableAdvertisingIdCollection method.
