### PR TITLE
copying google-play-services jar conflicts with other plugins

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,6 +19,8 @@
     <clobbers target="navigator.analytics" />
   </js-module>
 
+  <dependency id="com.google.playservices" />
+
   <platform name="ios">
     <config-file target="config.xml" parent="/*">
       <feature name="GoogleAnalytics">
@@ -63,8 +65,6 @@
     </config-file>
 
     <source-file src="android/GoogleAnalyticsPlugin.java" target-dir="src/com/cmackay/plugins/googleanalytics" />
-    <source-file src="android/google-play-services.jar" target-dir="libs" />
-    <source-file src="android/version.xml" target-dir="res/values" />
 
     <proguard-config>
 -keep class * extends java.util.ListResourceBundle {


### PR DESCRIPTION
I use a couple of other plugins that also use google-play-services.  If I attempt to test out your google analytics plugin while using the others, it ends up failing like this:

```
Installing "cc.fovea.cordova.purchase" for android
Installing "com.cmackay.plugins.googleanalytics" for android
Installing "com.google.cordova.admob" for android
Installing "com.rjfun.cordova.extension" for android
Installing "com.google.playservices" for android
Error during processing of action! Attempting to revert...
Failed to install 'com.google.playservices':Error: Uh oh!
"/Users/ranger/git/opennms-mobile/platforms/android/libs/google-play-services.jar" already exists!
    at Object.module.exports.common.copyNewFile (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/platforms/common.js:67:19)
    at module.exports.source-file.install (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/platforms/android.js:78:20)
    at Object.ActionStack.process (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/util/action-stack.js:67:25)
    at handleInstall (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:575:20)
    at /usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:335:28
    at _fulfilled (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:787:54)
    at self.promiseDispatch.done (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:816:30)
    at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:749:13)
    at /usr/local/lib/node_modules/cordova/node_modules/q/q.js:509:49
    at flush (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:108:17)
Failed to install 'com.google.cordova.admob':Error: Uh oh!
"/Users/ranger/git/opennms-mobile/platforms/android/libs/google-play-services.jar" already exists!
    at Object.module.exports.common.copyNewFile (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/platforms/common.js:67:19)
    at module.exports.source-file.install (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/platforms/android.js:78:20)
    at Object.ActionStack.process (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/util/action-stack.js:67:25)
    at handleInstall (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:575:20)
    at /usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:335:28
    at _fulfilled (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:787:54)
    at self.promiseDispatch.done (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:816:30)
    at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:749:13)
    at /usr/local/lib/node_modules/cordova/node_modules/q/q.js:509:49
    at flush (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:108:17)
Error: Uh oh!
"/Users/ranger/git/opennms-mobile/platforms/android/libs/google-play-services.jar" already exists!
    at Object.module.exports.common.copyNewFile (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/platforms/common.js:67:19)
    at module.exports.source-file.install (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/platforms/android.js:78:20)
    at Object.ActionStack.process (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/util/action-stack.js:67:25)
    at handleInstall (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:575:20)
    at /usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:335:28
    at _fulfilled (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:787:54)
    at self.promiseDispatch.done (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:816:30)
    at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:749:13)
    at /usr/local/lib/node_modules/cordova/node_modules/q/q.js:509:49
    at flush (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:108:17)
```

This pull request changes your plugin.xml so it has a dependency on "com.google.playservices" rather than hand-copying the jar and version.xml itself.  The upstream com.google.playservices version is identical to yours, so it should be equivalent.