### PR TITLE
Remove dependency and use cordova framework tag

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,8 +19,6 @@
     <clobbers target="navigator.analytics" />
   </js-module>
 
-  <dependency id="com.google.playservices" />
-
   <platform name="ios">
     <config-file target="config.xml" parent="/*">
       <feature name="GoogleAnalytics">
@@ -65,6 +63,8 @@
     </config-file>
 
     <source-file src="android/GoogleAnalyticsPlugin.java" target-dir="src/com/cmackay/plugins/googleanalytics" />
+
+    <framework src="com.google.android.gms:play-services-analytics:+" />
 
     <proguard-config>
 -keep class * extends java.util.ListResourceBundle {


### PR DESCRIPTION
As described at https://github.com/MobileChromeApps/google-play-services,
the google play services plugin is deprecated. Plugins should now use the
framework tags instead.

This also fixes a build error, i.e., `Error: more than one library with package name 'com.google.android.gms'` when using this plugin and the admob cordova plugin. Both use google play services, but (AFAIS) different versions.