### PR TITLE
Add App-level Opt Out

### DIFF
--- a/android/GoogleAnalyticsPlugin.java
+++ b/android/GoogleAnalyticsPlugin.java
@@ -27,6 +27,7 @@ import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CallbackContext;
+import org.apache.cordova.PluginResult;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -96,6 +97,14 @@ public class GoogleAnalyticsPlugin extends CordovaPlugin {
 
     } else if ("close".equals(action)) {
       close(rawArgs, callback);
+      return true;
+
+    } else if ("setAppOptOut".equals(action)) {
+      setAppOptOut(rawArgs, callback);
+      return true;
+
+    } else if ("getAppOptOut".equals(action)) {
+      getAppOptOut(callback);
       return true;
     }
 
@@ -232,6 +241,19 @@ public class GoogleAnalyticsPlugin extends CordovaPlugin {
       map.put(key, value);
     }
     return map;
+  }
+
+  private void setAppOptOut(final String rawArgs, CallbackContext callbackContext) {
+    try {
+      ga.setAppOptOut(new JSONArray(rawArgs).getBoolean(0));
+      callbackContext.success();
+    } catch (JSONException e) {
+      callbackContext.error(e.toString());
+    }
+  }
+
+  private void getAppOptOut(CallbackContext callbackContext) {
+    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, ga.getAppOptOut()));
   }
 
 }

--- a/ios/GoogleAnalyticsPlugin.h
+++ b/ios/GoogleAnalyticsPlugin.h
@@ -32,5 +32,7 @@
 - (void) set: (CDVInvokedUrlCommand*)command;
 - (void) send: (CDVInvokedUrlCommand*)command;
 - (void) close: (CDVInvokedUrlCommand*)command;
+- (void) getAppOptOut: (CDVInvokedUrlCommand*)command;
+- (void) setAppOptOut: (CDVInvokedUrlCommand*)command;
 
 @end

--- a/ios/GoogleAnalyticsPlugin.m
+++ b/ios/GoogleAnalyticsPlugin.m
@@ -125,4 +125,32 @@
   [self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
 }
 
+- (void) getAppOptOut: (CDVInvokedUrlCommand*)command
+{
+  CDVPluginResult* result = nil;
+
+  if ([GAI sharedInstance].optOut) {
+    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:(true)];
+  } else {
+    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:(false)];
+  }
+
+  [self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+}
+
+- (void) setAppOptOut: (CDVInvokedUrlCommand*)command
+{
+  CDVPluginResult* result = nil;
+  BOOL enabled = [[command.arguments objectAtIndex:0] boolValue];
+
+  if (enabled) {
+    [[GAI sharedInstance] setOptOut:YES];
+  } else {
+    [[GAI sharedInstance] setOptOut:NO];
+  }
+  result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+
+  [self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+}
+
 @end

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -265,7 +265,7 @@ Analytics.prototype = {
   },
 
   getAppOptOut: function (success) {
-    argscheck.checkArgs('fF', 'analytics.getAppOptOut', arguments);
+    argscheck.checkArgs('F', 'analytics.getAppOptOut', arguments);
     exec(success, null, 'GoogleAnalytics', 'getAppOptOut', []);
   },
 

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -257,7 +257,17 @@ Analytics.prototype = {
       }
       self.sendException(description, fatal, success, error);
     };
-  }
+  },
+
+  setAppOptOut: function (enabled, success, error) {
+    argscheck.checkArgs('*FF', 'analytics.setAppOptOut', arguments);
+    exec(success, error, 'GoogleAnalytics', 'setAppOptOut', [enabled]);
+  },
+
+  getAppOptOut: function (success) {
+    argscheck.checkArgs('fF', 'analytics.getAppOptOut', arguments);
+    exec(success, null, 'GoogleAnalytics', 'getAppOptOut', []);
+  },
 
 };
 


### PR DESCRIPTION
This PR adds application level [opt out](https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced?hl=en#optout) for [iOS](https://developers.google.com/analytics/devguides/collection/ios/v3/advanced#opt-out) and [Android](https://developers.google.com/analytics/devguides/collection/android/v4/advanced?hl=en#opt-out).

Examples:

```javascript
navigator.analytics.setAppOptOut(true, function() {
  // success
});
navigator.analytics.getAppOptOut(function (result) {
});
```

I've tested this on both platforms. Real-Time views in GA should be 0 when opt out is set to `true`. It might require another look on iOS. Objective-C is not my thing. ;)
