### PR TITLE
Feature/#64 multiple trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Gets a field value. Returned as argument to success callback
 If multiple trackers are being used, it returns an array of trackerId and
 field value pairs, e.g.,
 ```json
-[{ "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
+[{ "UA-XXXXX-1" : "field_value1" }, { "UA-XXXXX-2" : "field_value2" }]
 ```
 
 **Kind**: static method of <code>[analytics](#module_analytics)</code>  

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ var analytics = navigator.analytics;
 
 // set the tracking id
 analytics.setTrackingId('UA-XXXXX-X');
+// ...or set multiple tracking ids
+analytics.setMultipleTrackingIds(['UA-XXXXX-1', 'UA-XXXXX-2']);
 
 analytics.sendAppView('home', successCallback, errorCallback);
 
@@ -55,6 +57,7 @@ cordova plugin add com.cmackay.plugins.googleanalytics
   * [.HitTypes](#module_analytics.HitTypes)
   * [.LogLevel](#module_analytics.LogLevel)
   * [.setTrackingId(trackingId, [success], [error])](#module_analytics.setTrackingId)
+  * [.setMultipleTrackingIds(trackingIds, [success], [error])](#module_analytics.setMultipleTrackingIds)
   * [.setDispatchInterval(seconds, [success], [error])](#module_analytics.setDispatchInterval)
   * [.getAppOptOut([success])](#module_analytics.getAppOptOut)
   * [.setAppOptOut([enabled], [success], [error])](#module_analytics.setAppOptOut)
@@ -90,13 +93,25 @@ Log Levels
 **Kind**: static property of <code>[analytics](#module_analytics)</code>  
 <a name="module_analytics.setTrackingId"></a>
 ### analytics.setTrackingId(trackingId, [success], [error])
-Sets the tracking id
+Sets the tracking id. This will override any id or ids previously set.
 
 **Kind**: static method of <code>[analytics](#module_analytics)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | trackingId | <code>string</code> | the trackingId |
+| [success] | <code>function</code> | the success callback |
+| [error] | <code>function</code> | the error callback |
+
+<a name="module_analytics.setMultipleTrackingIds"></a>
+### analytics.setMultipleTrackingIds(trackingIds, [success], [error])
+Sets multiple tracking ids. This will override any id or ids previously set.
+
+**Kind**: static method of <code>[analytics](#module_analytics)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| trackingIds | <code>array</code> | the trackingId |
 | [success] | <code>function</code> | the success callback |
 | [error] | <code>function</code> | the error callback |
 
@@ -149,6 +164,12 @@ Sets the log level
 <a name="module_analytics.get"></a>
 ### analytics.get(key, success, [error])
 Gets a field value. Returned as argument to success callback
+
+If multiple trackers are being used, it returns an array of trackerId and
+field value pairs, e.g.,
+```json
+[{ "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
+```
 
 **Kind**: static method of <code>[analytics](#module_analytics)</code>  
 
@@ -320,4 +341,3 @@ to true).
 | [opts] | <code>object</code> | the options { formatter: Function, fatal: Boolean } |
 | [success] | <code>function</code> | the success callback |
 | [error] | <code>function</code> | the error callback |
-

--- a/android/GoogleAnalyticsPlugin.java
+++ b/android/GoogleAnalyticsPlugin.java
@@ -43,7 +43,7 @@ import java.util.Iterator;
 public class GoogleAnalyticsPlugin extends CordovaPlugin {
 
   private static GoogleAnalytics ga;
-  private static List<Tracker> trackers = new ArrayList();
+  private static List<Tracker> trackers = new ArrayList<Tracker>();
 
   /**
    * Initializes the plugin
@@ -115,7 +115,7 @@ public class GoogleAnalyticsPlugin extends CordovaPlugin {
 
   private void setTrackingId(String rawArgs, CallbackContext callback) {
     try {
-      trackers = new ArrayList();
+      trackers.clear();
       JSONArray jsonArray = new JSONArray(rawArgs);
       for (int i = 0; i < jsonArray.length(); i++) {
         trackers.add(ga.newTracker(new JSONArray(rawArgs).getString(i)));
@@ -247,12 +247,7 @@ public class GoogleAnalyticsPlugin extends CordovaPlugin {
         GoogleAnalyticsPlugin plugin = GoogleAnalyticsPlugin.this;
         if (plugin.hasTracker(callbackContext)) {
           plugin.ga.dispatchLocalHits();
-          Iterator<Tracker> it = plugin.trackers.iterator();
-          while (it.hasNext()) {
-            Tracker tracker = it.next();
-            it.remove();
-            tracker = null;
-          }
+          plugin.trackers.clear();
           callbackContext.success();
         }
       }

--- a/android/GoogleAnalyticsPlugin.java
+++ b/android/GoogleAnalyticsPlugin.java
@@ -184,7 +184,7 @@ public class GoogleAnalyticsPlugin extends CordovaPlugin {
         } else if (trackers.size() > 1) {
           /*
            * Returns an array of tracker id and value combinations, e.g.,
-           * [ { "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
+           * [{ "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
            */
           JSONArray jsonArray = new JSONArray();
           for (Tracker tracker : trackers) {
@@ -261,7 +261,7 @@ public class GoogleAnalyticsPlugin extends CordovaPlugin {
 
   private boolean hasTracker(CallbackContext callbackContext) {
     if (trackers.isEmpty()) {
-      callbackContext.error("Tracker not initialized. Call setTrackingId prior to using tracker.");
+      callbackContext.error("Tracker(s) not initialized. Call setTrackingId or setMultipleTrackingIds prior to using tracker.");
       return false;
     }
     return true;

--- a/ios/GAI.h
+++ b/ios/GAI.h
@@ -1,7 +1,7 @@
 /*!
  @header    GAI.h
  @abstract  Google Analytics iOS SDK Header
- @version   3.14
+ @version   3.17
  @copyright Copyright 2015 Google Inc. All rights reserved.
  */
 

--- a/ios/GAIDictionaryBuilder.h
+++ b/ios/GAIDictionaryBuilder.h
@@ -111,11 +111,8 @@
  * http://my.site.com/index.html?utm_campaign=wow&utm_source=source
  * utm_campaign=wow&utm_source=source.
  * <p>
- * For more information on auto-tagging, see
- * http://support.google.com/googleanalytics/bin/answer.py?hl=en&answer=55590
- * <p>
- * For more information on manual tagging, see
- * http://support.google.com/googleanalytics/bin/answer.py?hl=en&answer=55518
+ * For more information on manual and auto-tagging, see
+ * https://support.google.com/analytics/answer/1733663?hl=en
  */
 - (GAIDictionaryBuilder *)setCampaignParametersFromUrl:(NSString *)urlString;
 

--- a/ios/GoogleAnalyticsPlugin.h
+++ b/ios/GoogleAnalyticsPlugin.h
@@ -22,10 +22,11 @@
 #import "GAI.h"
 
 @interface GoogleAnalyticsPlugin : CDVPlugin {
-  id<GAITracker> tracker;
+  NSMutableArray *trackers;
 }
 
 - (void) setTrackingId: (CDVInvokedUrlCommand*)command;
+- (void) setMultipleTrackingIds: (CDVInvokedUrlCommand*)command;
 - (void) setDispatchInterval: (CDVInvokedUrlCommand*)command;
 - (void) setLogLevel: (CDVInvokedUrlCommand*)command;
 - (void) get: (CDVInvokedUrlCommand*)command;

--- a/ios/GoogleAnalyticsPlugin.m
+++ b/ios/GoogleAnalyticsPlugin.m
@@ -37,8 +37,8 @@
     for (NSUInteger i = 0; i < [trackers count]; i++) {
       [[GAI sharedInstance] removeTrackerByName:[[trackers objectAtIndex:i] name]];
     }
+    [trackers removeAllObjects];
   }
-  trackers = nil;
 }
 
 - (void) _setTrackingIds: (CDVInvokedUrlCommand*)command
@@ -47,7 +47,10 @@
 
   [self _releaseTrackers];
 
-  trackers = [[NSMutableArray alloc] initWithCapacity:[command.arguments count]];
+  if (!trackers) {
+    trackers = [[NSMutableArray alloc] initWithCapacity:[command.arguments count]];
+  }
+
   for (NSUInteger i = 0; i < [command.arguments count]; i++) {
     id<GAITracker> tracker = [[GAI sharedInstance] trackerWithTrackingId:[command.arguments objectAtIndex:i]];
     [trackers addObject:tracker];

--- a/ios/GoogleAnalyticsPlugin.m
+++ b/ios/GoogleAnalyticsPlugin.m
@@ -115,7 +115,7 @@
     } else {
         /*
          * Returns an array of tracker id and value combinations, e.g.,
-         * [ { "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
+         * [{ "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
          */
         NSMutableArray *array = [NSMutableArray arrayWithCapacity:[trackers count]];
         for (NSUInteger i = 0; i < [trackers count]; i++) {

--- a/ios/GoogleAnalyticsPlugin.m
+++ b/ios/GoogleAnalyticsPlugin.m
@@ -123,7 +123,7 @@
           NSString *tid = [tracker get:@"&tid"];
           NSString *value = [tracker get:key];
           NSMutableDictionary *dict = [[NSMutableDictionary alloc]init];
-          [dict setValue:value == nil ? @"" : value forKey:tid];
+          [dict setValue:value == nil ? [NSNull null] : value forKey:tid];
           [array addObject:dict];
         }
 

--- a/ios/GoogleAnalyticsPlugin.m
+++ b/ios/GoogleAnalyticsPlugin.m
@@ -110,7 +110,7 @@
   @try {
     NSString* key = [command.arguments objectAtIndex:0];
 
-    if (!trackers) {
+    if (!trackers || ![trackers count]) {
       result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"tracker(s) not initialized"];
     } else if ([trackers count] == 1) {
       id<GAITracker> tracker = [trackers objectAtIndex:0];
@@ -153,7 +153,7 @@
   NSString* key = [command.arguments objectAtIndex:0];
   NSString* value = [command.arguments objectAtIndex:1];
 
-  if (!trackers) {
+  if (!trackers || ![trackers count]) {
     result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"tracker(s) not initialized"];
   } else {
     for (NSUInteger i = 0; i < [trackers count]; i++) {
@@ -170,7 +170,7 @@
   CDVPluginResult* result = nil;
   NSDictionary* params = [command.arguments objectAtIndex:0];
 
-  if (!trackers) {
+  if (!trackers || ![trackers count]) {
     result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"tracker(s) not initialized"];
   } else {
     for (NSUInteger i = 0; i < [trackers count]; i++) {
@@ -186,7 +186,7 @@
 {
   CDVPluginResult* result = nil;
 
-  if (!trackers) {
+  if (!trackers || ![trackers count]) {
     result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"tracker(s) not initialized"];
   } else {
     [self _releaseTrackers];

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -212,7 +212,7 @@ module.exports = {
    * Gets a field value. Returned as argument to success callback.
    * If multiple trackers are being used, this returns an array of trackerId and
    * field value pairs, e.g.,
-   * [{ "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
+   * [{ "UA-XXXXX-1" : "field_value1" }, { "UA-XXXXX-2" : "field_value2" }]
    *
    * @param {string} key - the key
    * @param {function} success - the success callback

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -211,7 +211,7 @@ module.exports = {
   /**
    * Gets a field value. Returned as argument to success callback.
    * If multiple trackers are being used, this returns an array of trackerId and
-   * field value objects, e.g.,
+   * field value pairs, e.g.,
    * [{ "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
    *
    * @param {string} key - the key

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -144,13 +144,13 @@ module.exports = {
    * Sets multiple tracking ids.
    * This will override any tracking id previously set.
    *
-   * @param {array} trackingId - array of trackingId parameters
+   * @param {array} trackingIds - array of trackingId parameters
    * @param {function} [success] - the success callback
    * @param {function} [error] - the error callback
    */
-  setMultipleTrackingIds: function (trackingId, success, error) {
+  setMultipleTrackingIds: function (trackingIds, success, error) {
     argscheck.checkArgs('aFF', 'analytics.setTrackingId', arguments);
-    exec(success, error, 'GoogleAnalytics', 'setTrackingId', trackingId);
+    exec(success, error, 'GoogleAnalytics', 'setTrackingId', trackingIds);
   },
 
   /**
@@ -212,7 +212,7 @@ module.exports = {
    * Gets a field value. Returned as argument to success callback.
    * If multiple trackers are being used, this returns an array of trackerId and
    * field value objects, e.g.,
-   * [ { "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
+   * [{ "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
    *
    * @param {string} key - the key
    * @param {function} success - the success callback

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -141,6 +141,19 @@ module.exports = {
   },
 
   /**
+   * Sets multiple tracking ids.
+   * This will override any tracking id previously set.
+   *
+   * @param {array} trackingId - array of trackingId parameters
+   * @param {function} [success] - the success callback
+   * @param {function} [error] - the error callback
+   */
+  setMultipleTrackingIds: function (trackingId, success, error) {
+    argscheck.checkArgs('aFF', 'analytics.setTrackingId', arguments);
+    exec(success, error, 'GoogleAnalytics', 'setTrackingId', trackingId);
+  },
+
+  /**
    * Sets the dispatch Interval
    *
    * @param {number} seconds - the interval in seconds
@@ -196,7 +209,10 @@ module.exports = {
   },
 
   /**
-   * Gets a field value. Returned as argument to success callback
+   * Gets a field value. Returned as argument to success callback.
+   * If multiple trackers are being used, this returns an array of trackerId and
+   * field value objects, e.g.,
+   * [ { "tid1" : "param_value1" }, { "tid2" : "param_value2" }]
    *
    * @param {string} key - the key
    * @param {function} success - the success callback


### PR DESCRIPTION
Adds support for multiple trackers as discussed in issue #64.

I've tested the `setTrackingId`, `setMultipleTrackingIds` , `sendAppView` and `get` on both Android and iOS. I have not tested all API methods so far.

This also upgrades the iOS Google Analytics lib to v3.17.